### PR TITLE
chore: Revert to python 3.12 instead of 3.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTHON_VERSION=3.13
+ARG PYTHON_VERSION=3.12
 
 # Builder
 FROM python:${PYTHON_VERSION}-slim-bookworm AS builder
@@ -33,7 +33,7 @@ RUN set -eux && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Copy the Python dependencies from the builder stage
-COPY --from=builder /usr/local/lib/python3.13/site-packages/ /usr/local/lib/python3.13/site-packages/
+COPY --from=builder /usr/local/lib/python3.12/site-packages/ /usr/local/lib/python3.12/site-packages/
 COPY --from=builder /usr/local/bin/ /usr/local/bin
 
 WORKDIR /app/deploy

--- a/src/bouwblokken/actions.py
+++ b/src/bouwblokken/actions.py
@@ -73,10 +73,9 @@ class BouwblokActionsMixin:
         for punt in punten:
             hoogtepunt = punt.hoogtepunt
             if hoogtepunt.status.omschrijving == "Vervallen":
-                # TODO logger geeft error -> later naar kijken nu eerst oplossen op productie
-                # logger.warning(
-                #     f"Vervallen hoogtepunt {hoogtepunt} in bouwblok {punt.bouwblok}"
-                # )
+                logger.warning(
+                    f"Vervallen hoogtepunt {hoogtepunt} in bouwblok {punt.bouwblok}"
+                )
                 continue
             last_meting = (
                 MetingHerzien.objects.filter(hoogtepunt=hoogtepunt)


### PR DESCRIPTION
Reverted the python version from 3.13 to 3.12 because opencensus is not compatible. When moving to OpenTelemetry the python version can be updated again.